### PR TITLE
Loading the default tmux session only when using Alacritty

### DIFF
--- a/.file/common/fs
+++ b/.file/common/fs
@@ -56,11 +56,11 @@ function up() {
 }
 
 function fs() {
-  local -r args="$(if du -b /dev/null >/dev/null 2>&1; then
-    echo '-sbh'
+  if du -b /dev/null >/dev/null 2>&1; then
+    local -r args='-sbh'
   else
-    echo '-sh'
-  fi)"
+    local -r args='-sh'
+  fi
 
   if [[ -n ${*} ]]; then
     du "${args}" -- "${@}"

--- a/.file/os/linux/.bashrc
+++ b/.file/os/linux/.bashrc
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# It is not loading files and if not running interactively
+# It is not loading files if not running interactively
 case $- in
   *i*) ;;
   *) return ;;

--- a/.file/os/linux/.zshrc
+++ b/.file/os/linux/.zshrc
@@ -1,6 +1,6 @@
 ### ZSH Settings
 
-# It is not loading files and if not running interactively
+# It is not loading files if not running interactively
 case $- in
   *i*) ;;
   *) return ;;
@@ -36,11 +36,15 @@ if [ -f "${HOME}/.zgen/zgen.zsh" ]; then
 fi
 
 # Load the tmux "hack" session on zsh startup
-# Note: not loading tmux in sphynx benchmarks because it's not important for it
+# Notes:
+# - not loading tmux in sphynx benchmarks because it's not important for it
+# - not loading tmux if a screen session is currently active
+# - loading the tmux session only when using Alacritty
 if [[ $- == *i* ]] \
   && hash sx &>/dev/null \
   && [ -z "${SX_SHELL_BENCHMARK}" ] \
   && [ -z "${STY}" ] \
-  && [ -z "${TMUX}" ]; then
+  && [ -z "${TMUX}" ] \
+  && [ -n "${ALACRITTY_LOG}" ]; then
   sx terminal tmux force-attach hack
 fi

--- a/.file/os/osx/.bashrc
+++ b/.file/os/osx/.bashrc
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# It is not loading files and if not running interactively
+# It is not loading files if not running interactively
 case $- in
   *i*) ;;
   *) return ;;

--- a/.file/os/osx/.zshrc
+++ b/.file/os/osx/.zshrc
@@ -1,6 +1,6 @@
 ### ZSH Settings
 
-# It is not loading files and if not running interactively
+# It is not loading files if not running interactively
 case $- in
   *i*) ;;
   *) return ;;
@@ -36,11 +36,15 @@ if [ -f "${HOME}/.zgen/zgen.zsh" ]; then
 fi
 
 # Load the tmux "hack" session on zsh startup
-# Note: not loading tmux in sphynx benchmarks because it's not important for it
+# Notes:
+# - not loading tmux in sphynx benchmarks because it's not important for it
+# - not loading tmux if a screen session is currently active
+# - loading the tmux session only when using Alacritty
 if [[ $- == *i* ]] \
   && hash sx &>/dev/null \
   && [ -z "${SX_SHELL_BENCHMARK}" ] \
   && [ -z "${STY}" ] \
-  && [ -z "${TMUX}" ]; then
+  && [ -z "${TMUX}" ] \
+  && [ -n "${ALACRITTY_LOG}" ]; then
   sx terminal tmux force-attach hack
 fi


### PR DESCRIPTION
- Refactoring function "fs"
- Fixing grammar in user shellscript files (e.g .bashrc, .zshrc, ...)