### PR TITLE
Removing deprecated run flags from "kubernetes shell"

### DIFF
--- a/cli/kubernetes/core/shell.sh
+++ b/cli/kubernetes/core/shell.sh
@@ -109,8 +109,6 @@ EOF
     --labels "app=${container_name}" \
     --env 'SOURCE=sphynx' \
     --quiet \
-    --requests 'cpu=25m,memory=25Mi' \
-    --limits 'cpu=25m,memory=25Mi' \
     --grace-period '1'
 
   local -r remaining_pod="$(


### PR DESCRIPTION
References:
- https://github.com/kubernetes/kubernetes/pull/99732