### PR TITLE
Do not print full help message when no arguments are provided

### DIFF
--- a/cli/.internal/library/sphynx.sh
+++ b/cli/.internal/library/sphynx.sh
@@ -6,7 +6,7 @@ function sx::parse_arguments() {
   local -r docopts="${SPHYNXC_DIR}/.internal/docopt/docopts"
   local -r sphynxd="$(basename "${SPHYNXC_DIR}")"
 
-  if [[ ${*} == *'--help'* ]] || [ "${#}" == '0' ]; then
+  if [[ ${*} == *'--help'* ]]; then
     eval "$(${docopts} -h "${help}" : '--help')"
     exit 0
   elif [[ ${*} == *'--raw'* ]]; then


### PR DESCRIPTION
The Kubernetes commands usually do not require any arguments to be run.