### PR TITLE
Remove deprecated settings from Ansible playbooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/"
+      interval: 'weekly'
+  - package-ecosystem: 'docker'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,32 +1,32 @@
-name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - title: "Features"
+  - title: 'Features'
     labels:
-      - "enhancement"
-  - title: "Bug Fixes"
+      - 'enhancement'
+  - title: 'Bug Fixes'
     labels:
-      - "bug"
-  - title: "Maintenance"
+      - 'bug'
+  - title: 'Maintenance'
     labels:
-      - "chore"
-      - "documentation"
-      - "dependencies"
-      - "github_actions"
+      - 'chore'
+      - 'documentation'
+      - 'dependencies'
+      - 'github_actions'
 exclude-labels:
-  - "no-changelog"
-change-template: "- $TITLE (#$NUMBER)"
+  - 'no-changelog'
+change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'
 version-resolver:
   major:
     labels:
-      - "major"
+      - 'major'
   minor:
     labels:
-      - "minor"
+      - 'minor'
   patch:
     labels:
-      - "patch"
+      - 'patch'
   default: patch
 template: |
   ## What's changed

--- a/modules/cli/.internal/global-commands/fmt.sh
+++ b/modules/cli/.internal/global-commands/fmt.sh
@@ -27,8 +27,8 @@ function sx::self::fmt::run_prettier() {
 
     cd "${SPHYNX_DIR}" || exit 1
 
-    prettier --write '*/**/*.json'
-    prettier --write '*/**/*.{yml,yaml}'
+    prettier --single-quote --write '*/**/*.{yml,yaml}'
     prettier --single-quote --write '*/**/*.js'
+    prettier --write '*/**/*.json'
   )
 }

--- a/modules/cli/.internal/global-commands/lint.sh
+++ b/modules/cli/.internal/global-commands/lint.sh
@@ -56,7 +56,7 @@ function sx::self::lint::run_prettier() {
 
   cd "${SPHYNX_DIR}" || exit 1
 
-  prettier --check '*/**/*.{yml,yaml}'
-  prettier --check '*/**/*.json'
+  prettier --single-quote --check '*/**/*.{yml,yaml}'
   prettier --single-quote --check '*/**/*.js'
+  prettier --check '*/**/*.json'
 }

--- a/modules/dotfiles/dotbot.conf.yaml
+++ b/modules/dotfiles/dotbot.conf.yaml
@@ -3,7 +3,7 @@
       relink: true
       create: true
       force: true
-- clean: ["~"]
+- clean: ['~']
 - clean:
     ${HOME}/.sphynx:
       force: true

--- a/modules/playbooks/ansible.cfg
+++ b/modules/playbooks/ansible.cfg
@@ -3,7 +3,6 @@ inventory = local.inventory
 log_path = /tmp/sphynx.ansible.log
 
 gathering = smart
-stdout_callback = yaml
 
 system_warnings = True
 retry_files_enabled = False

--- a/modules/playbooks/linux/roles/apt/tasks/main.yml
+++ b/modules/playbooks/linux/roles/apt/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Updating all packages
   apt:
-    name: "*"
+    name: '*'
     state: latest
     update_cache: true
 
@@ -14,9 +14,9 @@
 
 - name: Enabling built-in repositories
   shell: add-apt-repository -y {{ item }}
-  loop: "{{ builtin_repositories }}"
+  loop: '{{ builtin_repositories }}'
 
 - name: Installing packages
   apt:
-    name: "{{ packages }}"
+    name: '{{ packages }}'
     state: present

--- a/modules/playbooks/linux/roles/docker/tasks/main.yml
+++ b/modules/playbooks/linux/roles/docker/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Detecting - Docker is available
   stat:
-    path: "/usr/bin/docker"
+    path: '/usr/bin/docker'
   register: docker
 
 - name: Installing Docker CE repository
@@ -17,7 +17,7 @@
 
 - name: Updating repositories cache and installing Docker CE
   apt:
-    name: ["docker-ce", "docker-ce-cli", "containerd.io"]
+    name: ['docker-ce', 'docker-ce-cli', 'containerd.io']
     state: present
     update_cache: yes
   when:
@@ -25,7 +25,7 @@
 
 - name: Adding current user to the docker group
   user:
-    name: "{{ ansible_env.USER }}"
+    name: '{{ ansible_env.USER }}'
     groups: docker
     append: true
   when:

--- a/modules/playbooks/linux/roles/dotfiles/tasks/fonts.yml
+++ b/modules/playbooks/linux/roles/dotfiles/tasks/fonts.yml
@@ -1,20 +1,20 @@
 - name: Fonts - Creating configuration directory
   file:
-    path: "{{ ansible_env.HOME }}/.fonts"
+    path: '{{ ansible_env.HOME }}/.fonts'
     mode: 0755
     state: directory
 
 - name: Fonts - Checking installation
   stat:
-    path: "{{ ansible_env.HOME }}/.fonts/FiraCode-Regular.ttf"
+    path: '{{ ansible_env.HOME }}/.fonts/FiraCode-Regular.ttf'
   register: font
 
 - name: Fonts - Downloading and installing
   unarchive:
     src: https://github.com/tonsky/FiraCode/releases/download/6.2/Fira_Code_v6.2.zip
-    dest: "{{ ansible_env.HOME }}/.fonts/"
+    dest: '{{ ansible_env.HOME }}/.fonts/'
     remote_src: yes
-    extra_opts: "-j"
+    extra_opts: '-j'
     include:
       - ttf/FiraCode-Bold.ttf
       - ttf/FiraCode-Light.ttf

--- a/modules/playbooks/linux/roles/dotfiles/tasks/fzf.yml
+++ b/modules/playbooks/linux/roles/dotfiles/tasks/fzf.yml
@@ -1,21 +1,21 @@
 - name: Detecting - Fuzzy Finder is available
   stat:
-    path: "{{ linuxbrew_directory }}/fzf"
+    path: '{{ linuxbrew_directory }}/fzf'
   register: fzf
 
 - name: Installing Fuzzy Finder package
-  command: "{{ linuxbrew_directory }}/brew install fzf"
+  command: '{{ linuxbrew_directory }}/brew install fzf'
   register: new_fzf
   when:
     - not fzf.stat.exists
 
 - name: Detecting - Fuzzy Finder requirements are installed (.fzf.bash and .fzf.zsh)
   stat:
-    path: "{{ ansible_env.HOME }}/.fzf.zsh"
+    path: '{{ ansible_facts["user_dir"] }}/.fzf.zsh'
   register: fzf_requirements
 
 - name: Installing Fuzzy Finder requirements
-  shell: "$({{ linuxbrew_directory }}/brew --prefix)/opt/fzf/install"
+  shell: '$({{ linuxbrew_directory }}/brew --prefix)/opt/fzf/install'
   when:
     - fzf.stat.exists or new_fzf.rc == 0
     - not fzf_requirements.stat.exists

--- a/modules/playbooks/linux/roles/dotfiles/tasks/main.yml
+++ b/modules/playbooks/linux/roles/dotfiles/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Detecting - Zsh is available
   stat:
-    path: "/usr/bin/zsh"
+    path: '/usr/bin/zsh'
   register: zsh
 
 - name: Installing Zsh package
@@ -16,20 +16,20 @@
 - name: Making Zsh the default shell
   become: true
   user:
-    name: "{{ ansible_env.USER }}"
-    shell: "/bin/zsh"
+    name: '{{ ansible_env.USER }}'
+    shell: '/bin/zsh'
   when:
     - zsh.stat.exists or new_zsh is success
     - lookup('env','SHELL') != '/bin/zsh'
 
 - name: Installing Dotfiles
-  command: "{{ sphynx_cli }} workstation setup --dotfiles"
+  command: '{{ sphynx_cli }} workstation setup --dotfiles'
   when:
     - zsh.stat.exists or new_zsh is success
 
 - name: Include additional tasks
   include_tasks:
-    file: "{{ item }}"
+    file: '{{ item }}'
   loop:
     - vundle.yml
     - fonts.yml

--- a/modules/playbooks/linux/roles/dotfiles/tasks/starship.yml
+++ b/modules/playbooks/linux/roles/dotfiles/tasks/starship.yml
@@ -1,15 +1,15 @@
 - name: Creating Starship configuration directory
-  file: "path={{ ansible_env.HOME }}/.config/starship mode=0755 state=directory"
+  file: 'path={{ ansible_facts["user_dir"] }}/.config/starship mode=0755 state=directory'
 
 - name: Detecting - Starship is available
   stat:
-    path: "{{ ansible_env.HOME }}/.config/starship/starship.toml"
+    path: '{{ ansible_facts["user_dir"] }}/.config/starship/starship.toml'
   register: starship
 
 - name: Installing Starship settings
   file:
-    src: "{{ sphynx_settings_directory }}/common/starship/starship.toml"
-    dest: "{{ ansible_env.HOME }}/.config/starship/starship.toml"
+    src: '{{ sphynx_settings_directory }}/common/starship/starship.toml'
+    dest: '{{ ansible_facts["user_dir"] }}/.config/starship/starship.toml'
     state: link
     force: yes
   when:

--- a/modules/playbooks/linux/roles/dotfiles/tasks/terminal.yml
+++ b/modules/playbooks/linux/roles/dotfiles/tasks/terminal.yml
@@ -1,15 +1,15 @@
 - name: Creating Alacritty configuration directory
-  file: "path={{ ansible_env.HOME }}/.config/alacritty mode=0755 state=directory"
+  file: 'path={{ ansible_facts["user_dir"] }}/.config/alacritty mode=0755 state=directory'
 
 - name: Detecting - Alacrity is available
   stat:
-    path: "{{ ansible_env.HOME }}/.config/alacritty/alacritty.toml"
+    path: '{{ ansible_facts["user_dir"] }}/.config/alacritty/alacritty.toml'
   register: alacritty
 
 - name: Installing Alacritty settings
   file:
-    src: "{{ sphynx_settings_directory }}/linux/alacritty/alacritty.toml"
-    dest: "{{ ansible_env.HOME }}/.config/alacritty/alacritty.toml"
+    src: '{{ sphynx_settings_directory }}/linux/alacritty/alacritty.toml'
+    dest: '{{ ansible_facts["user_dir"] }}/.config/alacritty/alacritty.toml'
     state: link
     force: yes
   when:

--- a/modules/playbooks/linux/roles/dotfiles/tasks/vundle.yml
+++ b/modules/playbooks/linux/roles/dotfiles/tasks/vundle.yml
@@ -1,15 +1,15 @@
 - name: Creating VIM configuration directories
-  file: "path={{ directory_item }} mode=0755 state=directory"
+  file: 'path={{ directory_item }} mode=0755 state=directory'
   loop:
-    - "{{ ansible_env.HOME }}/.vim/backups"
-    - "{{ ansible_env.HOME }}/.vim/swaps"
-    - "{{ ansible_env.HOME }}/.vim/undo"
+    - '{{ ansible_facts["user_dir"] }}/.vim/backups'
+    - '{{ ansible_facts["user_dir"] }}/.vim/swaps'
+    - '{{ ansible_facts["user_dir"] }}/.vim/undo'
   loop_control:
     loop_var: directory_item
 
 - name: Detecting - Vundle is available
   stat:
-    path: "{{ ansible_env.HOME }}/.vim/bundle/Vundle.vim"
+    path: '{{ ansible_facts["user_dir"] }}/.vim/bundle/Vundle.vim'
   register: vundle
 
 - name: Installing Vundle plugins

--- a/modules/playbooks/linux/roles/firefox-developer-edition/tasks/main.yml
+++ b/modules/playbooks/linux/roles/firefox-developer-edition/tasks/main.yml
@@ -1,17 +1,17 @@
 - name: Detecting - Firefox Developer Edition is available
   stat:
-    path: "{{ ansible_env.HOME }}/.local/bin/firefox-developer-edition"
+    path: '{{ ansible_facts["user_dir"] }}/.local/bin/firefox-developer-edition'
   register: firefox
 
 - name: Downloading Firefox Developer Edition
   get_url:
-    url: "{{ firefox_url }}"
-    dest: "{{ firefox_dest }}"
+    url: '{{ firefox_url }}'
+    dest: '{{ firefox_dest }}'
   when:
     - not firefox.stat.exists
 
 - name: Creating directory for Firefox Developer Edition
-  file: "path=/opt/firefox-developer-edition mode=0755 state=directory"
+  file: 'path=/opt/firefox-developer-edition mode=0755 state=directory'
   become: true
   when:
     - not firefox.stat.exists
@@ -19,7 +19,7 @@
 - name: Unarchiving Firefox Developer Edition
   become: true
   unarchive:
-    src: "{{ firefox_dest }}"
+    src: '{{ firefox_dest }}'
     dest: /opt/firefox-developer-edition
     remote_src: yes
   when:
@@ -35,7 +35,7 @@
 
 - name: Creating bin directory
   file:
-    path: "{{ ansible_env.HOME }}/.local/bin"
+    path: '{{ ansible_facts["user_dir"] }}/.local/bin'
     mode: 0755
     state: directory
   when:
@@ -44,7 +44,7 @@
 - name: Creating link for Firefox Developer Edition
   file:
     src: /opt/firefox-developer-edition/firefox/firefox
-    dest: "{{ ansible_env.HOME }}/.local/bin/firefox-developer-edition"
+    dest: '{{ ansible_facts["user_dir"] }}/.local/bin/firefox-developer-edition'
     state: link
   when:
     - not firefox.stat.exists
@@ -52,6 +52,6 @@
 - name: Creating Firefox Developer Edition launcher
   template:
     src: firefox-developer-edition.desktop.j2
-    dest: "{{ ansible_env.HOME }}/.local/share/applications/firefox-developer-edition.desktop"
+    dest: '{{ ansible_facts["user_dir"] }}/.local/share/applications/firefox-developer-edition.desktop'
   when:
     - not firefox.stat.exists

--- a/modules/playbooks/linux/roles/git/tasks/main.yml
+++ b/modules/playbooks/linux/roles/git/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Cloning repositories
-  git: "repo={{ item.repo }} dest={{ item.dest }} update=no"
-  loop: "{{ repositories }}"
+  git: 'repo={{ item.repo }} dest={{ item.dest }} update=no'
+  loop: '{{ repositories }}'
 
 - name: Running hooks
-  shell: "{{ item.hooks }}"
-  loop: "{{ repositories }}"
+  shell: '{{ item.hooks }}'
+  loop: '{{ repositories }}'
   when:
     - item.hooks is defined

--- a/modules/playbooks/linux/roles/git/vars/main.yml
+++ b/modules/playbooks/linux/roles/git/vars/main.yml
@@ -1,7 +1,7 @@
 repositories:
-  - repo: "https://github.com/VundleVim/Vundle.vim"
-    dest: "{{ ansible_env.HOME }}/.vim/bundle/Vundle.vim"
-  - repo: "https://github.com/jandamm/zgenom.git"
-    dest: "{{ ansible_env.HOME }}/.zgenom"
-  - repo: "https://github.com/tmux-plugins/tpm"
-    dest: "{{ ansible_env.HOME }}/.tmux/plugins/tpm"
+  - repo: 'https://github.com/VundleVim/Vundle.vim'
+    dest: '{{ ansible_facts["user_dir"] }}/.vim/bundle/Vundle.vim'
+  - repo: 'https://github.com/jandamm/zgenom.git'
+    dest: '{{ ansible_facts["user_dir"] }}/.zgenom'
+  - repo: 'https://github.com/tmux-plugins/tpm'
+    dest: '{{ ansible_facts["user_dir"] }}/.tmux/plugins/tpm'

--- a/modules/playbooks/linux/roles/go/defaults/main.yml
+++ b/modules/playbooks/linux/roles/go/defaults/main.yml
@@ -1,1 +1,1 @@
-go_bin: "{{ linuxbrew_directory }}/go"
+go_bin: '{{ linuxbrew_directory }}/go'

--- a/modules/playbooks/linux/roles/go/tasks/main.yml
+++ b/modules/playbooks/linux/roles/go/tasks/main.yml
@@ -1,8 +1,8 @@
 - name: Creating Go configuration directory
   file:
-    path: "{{ workspace }}"
+    path: '{{ workspace }}'
     state: directory
 
 - name: Installing Go packages
-  shell: "GOPATH={{ workspace }} {{ go_bin }} install {{ item.repository }}"
-  loop: "{{ packages }}"
+  shell: 'GOPATH={{ workspace }} {{ go_bin }} install {{ item.repository }}'
+  loop: '{{ packages }}'

--- a/modules/playbooks/linux/roles/go/vars/main.yml
+++ b/modules/playbooks/linux/roles/go/vars/main.yml
@@ -1,5 +1,5 @@
-workspace: "{{ ansible_env.HOME }}/.go" # GOPATH
+workspace: '{{ ansible_facts["user_dir"] }}/.go' # GOPATH
 
 packages:
   - name: envsubst
-    repository: "github.com/a8m/envsubst/cmd/envsubst@latest"
+    repository: 'github.com/a8m/envsubst/cmd/envsubst@latest'

--- a/modules/playbooks/linux/roles/google-chrome/tasks/main.yml
+++ b/modules/playbooks/linux/roles/google-chrome/tasks/main.yml
@@ -1,12 +1,12 @@
 - name: Detecting - Google Chrome is available
   stat:
-    path: "/usr/bin/google-chrome"
+    path: '/usr/bin/google-chrome'
   register: chrome
 
 - name: Downloading Google Chrome
   get_url:
-    url: "{{ google_chrome_url }}"
-    dest: "{{ google_chrome_dest }}"
+    url: '{{ google_chrome_url }}'
+    dest: '{{ google_chrome_dest }}'
   when:
     - not chrome.stat.exists
 

--- a/modules/playbooks/linux/roles/jetbrains-toolbox/tasks/main.yml
+++ b/modules/playbooks/linux/roles/jetbrains-toolbox/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Detecting latest Jetbrains Toolbox version
   uri:
-    url: "{{ toolbox_version_url }}"
+    url: '{{ toolbox_version_url }}'
     method: GET
     return_content: yes
     body_format: json
@@ -16,13 +16,13 @@
 - name: Downloading Jetbrains Toolbox
   get_url:
     url: "https://download-cf.jetbrains.com/toolbox/jetbrains-toolbox-{{ toolbox_version_response.json.version.split(',')[-1] }}.tar.gz"
-    dest: "{{ toolbox_dest }}"
+    dest: '{{ toolbox_dest }}'
   when:
     - not toolbox_folder.stat.exists
 
 - name: Unarchiving Jetbrains Toolbox
   unarchive:
-    src: "{{ toolbox_dest }}"
+    src: '{{ toolbox_dest }}'
     dest: /tmp
     remote_src: yes
   when:
@@ -44,6 +44,6 @@
 - name: Creating Jetbrains Toolbox launcher
   template:
     src: jetbrains-toolbox.desktop.j2
-    dest: "{{ ansible_env.HOME }}/.local/share/applications/jetbrains-toolbox.desktop"
+    dest: '{{ ansible_facts["user_dir"] }}/.local/share/applications/jetbrains-toolbox.desktop'
   when:
     - not toolbox_folder.stat.exists

--- a/modules/playbooks/linux/roles/linuxbrew/defaults/main.yml
+++ b/modules/playbooks/linux/roles/linuxbrew/defaults/main.yml
@@ -1,1 +1,1 @@
-brew_path: "{{ linuxbrew_directory }}/brew"
+brew_path: '{{ linuxbrew_directory }}/brew'

--- a/modules/playbooks/linux/roles/linuxbrew/tasks/main.yml
+++ b/modules/playbooks/linux/roles/linuxbrew/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Updating packages
-  command: "{{ brew_path }} update"
+  command: '{{ brew_path }} update'
 
 - name: Installing packages
-  shell: "{{ brew_path }} install {{ item }}"
-  loop: "{{ packages }}"
+  shell: '{{ brew_path }} install {{ item }}'
+  loop: '{{ packages }}'

--- a/modules/playbooks/linux/roles/scripts/tasks/main.yml
+++ b/modules/playbooks/linux/roles/scripts/tasks/main.yml
@@ -1,17 +1,17 @@
 - name: Detecting - Inventory is available
   stat:
-    path: "{{ inventory_path }}"
+    path: '{{ inventory_path }}'
   register: inventory
 
 - name: Getting current inventory state
-  shell: "test -f {{ inventory_path }} && cat {{ inventory_path }} || true"
+  shell: 'test -f {{ inventory_path }} && cat {{ inventory_path }} || true'
   register: inventory_state
   changed_when: false
   when:
     - inventory.stat.exists
 
 - name: Applying scripts
-  script: "{{ item }}"
+  script: '{{ item }}'
   with_items:
     - "{{ lookup('fileglob', '*.sh').split(',') }}"
   register: scripts
@@ -20,7 +20,7 @@
 
 - name: Creating inventory file
   file:
-    path: "{{ inventory_path }}"
+    path: '{{ inventory_path }}'
     state: touch
   when:
     - not inventory.stat.exists
@@ -29,7 +29,7 @@
 - name: Updating inventory with current state
   lineinfile:
     line: "{{ lookup('file', item) | checksum }}"
-    dest: "{{ inventory_path }}"
+    dest: '{{ inventory_path }}'
     state: present
   with_items:
     - "{{ lookup('fileglob', '*.sh').split(',') }}"

--- a/modules/playbooks/linux/roles/snap/tasks/main.yml
+++ b/modules/playbooks/linux/roles/snap/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Installing packages
   community.general.snap:
-    name: "{{ item.name | default(item) }}"
-    classic: "{{ item.classic | default(False) }}"
+    name: '{{ item.name | default(item) }}'
+    classic: '{{ item.classic | default(False) }}'
     state: present
-  loop: "{{ packages }}"
+  loop: '{{ packages }}'

--- a/modules/playbooks/linux/roles/vscode/tasks/main.yml
+++ b/modules/playbooks/linux/roles/vscode/tasks/main.yml
@@ -6,22 +6,22 @@
   become: true
 
 - name: Creating VSCode directories
-  file: "path={{ ansible_env.HOME }}/.config/Code/User state=directory"
+  file: 'path={{ ansible_facts["user_dir"] }}/.config/Code/User state=directory'
 
 - name: Installing personal VSCode settings
   file:
-    src: "{{ sphynx_settings_directory }}/linux/vscode/{{ item }}"
-    dest: "{{ ansible_env.HOME }}/.config/Code/User/{{ item }}"
+    src: '{{ sphynx_settings_directory }}/linux/vscode/{{ item }}'
+    dest: '{{ ansible_facts["user_dir"] }}/.config/Code/User/{{ item }}'
     state: link
     force: yes
-  loop: "{{ configuration_files }}"
+  loop: '{{ configuration_files }}'
 
 - name: Getting all installed VSCode extensions
-  command: "code --list-extensions"
+  command: 'code --list-extensions'
   register: installed_extensions
 
 - name: Installing VSCode extensions
-  command: "code --install-extension {{ item.name | default(item) }}"
-  loop: "{{ extensions }}"
+  command: 'code --install-extension {{ item.name | default(item) }}'
+  loop: '{{ extensions }}'
   when:
     - item.name | default(item) not in installed_extensions.stdout

--- a/modules/playbooks/macos/roles/defaults/tasks/main.yml
+++ b/modules/playbooks/macos/roles/defaults/tasks/main.yml
@@ -1,10 +1,10 @@
 - name: Checking inventory file
   stat:
-    path: "{{ inventory_path }}"
+    path: '{{ inventory_path }}'
   register: inventory
 
 - name: Checking inventory state
-  shell: "test -f {{ inventory_path }} && cat {{ inventory_path }} || true"
+  shell: 'test -f {{ inventory_path }} && cat {{ inventory_path }} || true'
   register: inventory_state
   changed_when: false
   when:
@@ -15,7 +15,7 @@
     osascript -e 'tell application "System Preferences" to quit'
 
 - name: Applying defaults
-  script: "{{ item }}"
+  script: '{{ item }}'
   with_items:
     - "{{ lookup('fileglob', '*.defaults').split(',') }}"
   register: defaults
@@ -29,7 +29,7 @@
 
 - name: Creating inventory file
   file:
-    path: "{{ inventory_path }}"
+    path: '{{ inventory_path }}'
     state: touch
   when:
     - not inventory.stat.exists
@@ -38,7 +38,7 @@
 - name: Updating inventory with current state
   lineinfile:
     line: "{{ lookup('file', item) | checksum }}"
-    dest: "{{ inventory_path }}"
+    dest: '{{ inventory_path }}'
     state: present
   with_items:
     - "{{ lookup('fileglob', '*.defaults').split(',') }}"

--- a/modules/playbooks/macos/roles/dock/tasks/main.yml
+++ b/modules/playbooks/macos/roles/dock/tasks/main.yml
@@ -9,8 +9,8 @@
     - applications != current_items.stdout.split('\n')
 
 - name: Adding new items
-  shell: "dockutil --no-restart --add '{{ item }}' '{{ ansible_env.HOME }}/Library/Preferences/com.apple.dock.plist'"
-  loop: "{{ applications }}"
+  shell: 'dockutil --no-restart --add ''{{ item }}'' ''{{ ansible_facts["user_dir"] }}/Library/Preferences/com.apple.dock.plist'''
+  loop: '{{ applications }}'
   notify:
     - Restart Dock
   when:

--- a/modules/playbooks/macos/roles/dock/vars/main.yml
+++ b/modules/playbooks/macos/roles/dock/vars/main.yml
@@ -1,11 +1,11 @@
 applications:
-  - "/System/Applications/Mail.app"
-  - "/Applications/Google Chrome.app"
-  - "/Applications/Slack.app"
-  - "/Applications/Telegram Lite.app"
-  - "/Applications/WhatsApp.app"
-  - "/Applications/Spotify.app"
-  - "/System/Applications/Calendar.app"
-  - "/Applications/GitHub Desktop.app"
-  - "/Applications/Obsidian.app"
-  - "/Applications/Ghostty.app"
+  - '/System/Applications/Mail.app'
+  - '/Applications/Google Chrome.app'
+  - '/Applications/Slack.app'
+  - '/Applications/Telegram Lite.app'
+  - '/Applications/WhatsApp.app'
+  - '/Applications/Spotify.app'
+  - '/System/Applications/Calendar.app'
+  - '/Applications/GitHub Desktop.app'
+  - '/Applications/Obsidian.app'
+  - '/Applications/Ghostty.app'

--- a/modules/playbooks/macos/roles/dotfiles/tasks/editor.yml
+++ b/modules/playbooks/macos/roles/dotfiles/tasks/editor.yml
@@ -1,12 +1,12 @@
 - name: Zed - Creating configuration directory
   file:
-    path: "{{ ansible_env.HOME }}/.config/zed"
+    path: '{{ ansible_facts["user_dir"] }}/.config/zed'
     mode: 0755
     state: directory
 
 - name: Zed - Installing personal settings
   file:
-    src: "{{ sphynx_settings_directory }}/macos/zed/settings.json"
-    dest: "{{ ansible_env.HOME }}/.config/zed/settings.json"
+    src: '{{ sphynx_settings_directory }}/macos/zed/settings.json'
+    dest: '{{ ansible_facts["user_dir"] }}/.config/zed/settings.json'
     state: link
     force: yes

--- a/modules/playbooks/macos/roles/dotfiles/tasks/fonts.yml
+++ b/modules/playbooks/macos/roles/dotfiles/tasks/fonts.yml
@@ -1,20 +1,20 @@
 - name: Fonts - Creating configuration directory
   file:
-    path: "{{ ansible_env.HOME }}/Library/Fonts"
+    path: '{{ ansible_facts["user_dir"] }}/Library/Fonts'
     mode: 0755
     state: directory
 
 - name: Fonts - Checking installation
   stat:
-    path: "{{ ansible_env.HOME }}/Library/Fonts/FiraCode-Regular.ttf"
+    path: '{{ ansible_facts["user_dir"] }}/Library/Fonts/FiraCode-Regular.ttf'
   register: font
 
 - name: Fonts - Downloading and installing
   unarchive:
     src: https://github.com/tonsky/FiraCode/releases/download/6.2/Fira_Code_v6.2.zip
-    dest: "{{ ansible_env.HOME }}/Library/Fonts/"
+    dest: '{{ ansible_facts["user_dir"] }}/Library/Fonts/'
     remote_src: yes
-    extra_opts: "-j"
+    extra_opts: '-j'
     include:
       - ttf/FiraCode-Bold.ttf
       - ttf/FiraCode-Light.ttf

--- a/modules/playbooks/macos/roles/dotfiles/tasks/main.yml
+++ b/modules/playbooks/macos/roles/dotfiles/tasks/main.yml
@@ -13,17 +13,17 @@
     - lookup('env','SHELL') != '/usr/local/bin/zsh'
 
 - name: Setting default shell
-  shell: "chsh -s /usr/local/bin/zsh {{ ansible_env.USER }}"
+  shell: 'chsh -s /usr/local/bin/zsh {{ ansible_env.USER }}'
   become: true
   when:
     - lookup('env','SHELL') != '/usr/local/bin/zsh'
 
 - name: Configuring Dotfiles
-  command: "{{ sphynx_cli }} workstation setup --dotfiles"
+  command: '{{ sphynx_cli }} workstation setup --dotfiles'
 
 - name: Include additional tasks
   include_tasks:
-    file: "{{ item }}"
+    file: '{{ item }}'
   loop:
     - vundle.yml
     - fonts.yml

--- a/modules/playbooks/macos/roles/dotfiles/tasks/rectangle.yml
+++ b/modules/playbooks/macos/roles/dotfiles/tasks/rectangle.yml
@@ -1,18 +1,18 @@
 - name: Rectangle - Creating configuration directory
   file:
-    path: "{{ ansible_env.HOME }}/Library/Application Support/Rectangle"
+    path: '{{ ansible_facts["user_dir"] }}/Library/Application Support/Rectangle'
     mode: 0755
     state: directory
 
 - name: Rectangle - Checking installation
   stat:
-    path: "{{ ansible_env.HOME }}/Library/Application Support/Rectangle/RectangleConfig.json"
+    path: '{{ ansible_facts["user_dir"] }}/Library/Application Support/Rectangle/RectangleConfig.json'
   register: rectangle
 
 - name: Rectangle - Installing personal settings
   file:
-    src: "{{ sphynx_settings_directory }}/macos/rectangle/RectangleConfig.json"
-    dest: "{{ ansible_env.HOME }}/Library/Application Support/Rectangle/RectangleConfig.json"
+    src: '{{ sphynx_settings_directory }}/macos/rectangle/RectangleConfig.json'
+    dest: '{{ ansible_facts["user_dir"] }}/Library/Application Support/Rectangle/RectangleConfig.json'
     state: link
     force: yes
   when:

--- a/modules/playbooks/macos/roles/dotfiles/tasks/starship.yml
+++ b/modules/playbooks/macos/roles/dotfiles/tasks/starship.yml
@@ -1,12 +1,12 @@
 - name: Starship - Creating configuration directory
   file:
-    path: "{{ ansible_env.HOME }}/.config/starship"
-    mode: "0755"
+    path: '{{ ansible_facts["user_dir"] }}/.config/starship'
+    mode: '0755'
     state: directory
 
 - name: Starship - Installing personal settings
   file:
-    src: "{{ sphynx_settings_directory }}/common/starship/starship.toml"
-    dest: "{{ ansible_env.HOME }}/.config/starship/starship.toml"
+    src: '{{ sphynx_settings_directory }}/common/starship/starship.toml'
+    dest: '{{ ansible_facts["user_dir"] }}/.config/starship/starship.toml'
     state: link
     force: yes

--- a/modules/playbooks/macos/roles/dotfiles/tasks/terminal.yml
+++ b/modules/playbooks/macos/roles/dotfiles/tasks/terminal.yml
@@ -1,12 +1,12 @@
 - name: Ghostty - Creating configuration directory
   file:
-    path: "{{ ansible_env.HOME }}/Library/Application Support/com.mitchellh.ghostty"
-    mode: "0755"
+    path: '{{ ansible_facts["user_dir"] }}/Library/Application Support/com.mitchellh.ghostty'
+    mode: '0755'
     state: directory
 
 - name: Ghostty - Installing personal settings
   file:
-    src: "{{ sphynx_settings_directory }}/macos/ghostty/config"
-    dest: "{{ ansible_env.HOME }}/Library/Application Support/com.mitchellh.ghostty/config"
+    src: '{{ sphynx_settings_directory }}/macos/ghostty/config'
+    dest: '{{ ansible_facts["user_dir"] }}/Library/Application Support/com.mitchellh.ghostty/config'
     state: link
     force: yes

--- a/modules/playbooks/macos/roles/dotfiles/tasks/vundle.yml
+++ b/modules/playbooks/macos/roles/dotfiles/tasks/vundle.yml
@@ -1,18 +1,18 @@
 - name: Vundle - Creating configuration directories
   file:
-    path: "{{ directory_item }}"
-    mode: "0755"
+    path: '{{ directory_item }}'
+    mode: '0755'
     state: directory
   loop:
-    - "{{ ansible_env.HOME }}/.vim/backups"
-    - "{{ ansible_env.HOME }}/.vim/swaps"
-    - "{{ ansible_env.HOME }}/.vim/undo"
+    - '{{ ansible_facts["user_dir"] }}/.vim/backups'
+    - '{{ ansible_facts["user_dir"] }}/.vim/swaps'
+    - '{{ ansible_facts["user_dir"] }}/.vim/undo'
   loop_control:
     loop_var: directory_item
 
 - name: Vundle - Checking installation
   stat:
-    path: "{{ ansible_env.HOME }}/.vim/bundle/Vundle.vim"
+    path: '{{ ansible_facts["user_dir"] }}/.vim/bundle/Vundle.vim'
   register: vundle
 
 - name: Vundle - Installing plugins

--- a/modules/playbooks/macos/roles/fzf/tasks/main.yml
+++ b/modules/playbooks/macos/roles/fzf/tasks/main.yml
@@ -5,10 +5,10 @@
 
 - name: Checking - Fuzzy Finder installation
   stat:
-    path: "{{ ansible_env.HOME }}/.fzf.zsh"
+    path: '{{ ansible_facts["user_dir"] }}/.fzf.zsh'
   register: fzf
 
 - name: Installing Fuzzy Finder completion + key bindings
-  shell: "$(brew --prefix)/opt/fzf/install"
+  shell: '$(brew --prefix)/opt/fzf/install'
   when:
     - not fzf.stat.exists

--- a/modules/playbooks/macos/roles/git/tasks/main.yml
+++ b/modules/playbooks/macos/roles/git/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Cloning repositories
   git:
-    repo: "{{ item.origin_url }}"
-    dest: "{{ item.directory }}"
-  loop: "{{ repositories }}"
+    repo: '{{ item.origin_url }}'
+    dest: '{{ item.directory }}'
+  loop: '{{ repositories }}'

--- a/modules/playbooks/macos/roles/git/vars/main.yml
+++ b/modules/playbooks/macos/roles/git/vars/main.yml
@@ -1,5 +1,5 @@
 repositories:
-  - origin_url: "https://github.com/VundleVim/Vundle.vim"
-    directory: "{{ ansible_env.HOME }}/.vim/bundle/Vundle.vim"
-  - origin_url: "https://github.com/tmux-plugins/tpm"
-    directory: "{{ ansible_env.HOME }}/.tmux/plugins/tpm"
+  - origin_url: 'https://github.com/VundleVim/Vundle.vim'
+    directory: '{{ ansible_facts["user_dir"] }}/.vim/bundle/Vundle.vim'
+  - origin_url: 'https://github.com/tmux-plugins/tpm'
+    directory: '{{ ansible_facts["user_dir"] }}/.tmux/plugins/tpm'

--- a/modules/playbooks/macos/roles/homebrew/tasks/main.yml
+++ b/modules/playbooks/macos/roles/homebrew/tasks/main.yml
@@ -1,10 +1,10 @@
 - name: Checking /usr/local/bin directory
   stat:
-    path: "/usr/local/bin"
+    path: '/usr/local/bin'
   register: local_bin
 
 - name: Moving all /usr/local/bin content to /opt/homebrew/bin
-  shell: "mv /usr/local/bin/* /opt/homebrew/bin/ || true"
+  shell: 'mv /usr/local/bin/* /opt/homebrew/bin/ || true'
   become: true
   when:
     - local_bin.stat.islnk is not defined
@@ -13,8 +13,8 @@
 
 - name: Creating symbolic link from /usr/local/bin to /opt/homebrew/bin
   file:
-    src: "/opt/homebrew/bin"
-    dest: "/usr/local/bin"
+    src: '/opt/homebrew/bin'
+    dest: '/usr/local/bin'
     state: link
     force: true
   become: true
@@ -25,9 +25,9 @@
 
 - name: Tapping repositories
   community.general.homebrew_tap:
-    name: "{{ item }}"
+    name: '{{ item }}'
     state: present
-  loop: "{{ repositories }}"
+  loop: '{{ repositories }}'
 
 - name: Updating Homebrew
   community.general.homebrew:
@@ -43,11 +43,11 @@
 
 - name: Installing Homebrew formulas
   community.general.homebrew:
-    name: "{{ item }}"
+    name: '{{ item }}'
     state: present
-  loop: "{{ formulas }}"
+  loop: '{{ formulas }}'
 
 - name: Installing Homebrew casks
   community.general.homebrew_cask:
-    name: "{{ item }}"
-  loop: "{{ casks }}"
+    name: '{{ item }}'
+  loop: '{{ casks }}'

--- a/modules/playbooks/macos/roles/karabiner/tasks/main.yml
+++ b/modules/playbooks/macos/roles/karabiner/tasks/main.yml
@@ -5,13 +5,13 @@
 
 - name: Creating directories
   file:
-    path: "{{ ansible_env.HOME }}/.config/karabiner"
+    path: '{{ ansible_facts["user_dir"] }}/.config/karabiner'
     state: directory
 
 - name: Installing personal settings
   file:
-    src: "{{ sphynx_settings_directory }}/macos/karabiner-elements/karabiner.json"
-    dest: "{{ ansible_env.HOME }}/.config/karabiner/karabiner.json"
+    src: '{{ sphynx_settings_directory }}/macos/karabiner-elements/karabiner.json'
+    dest: '{{ ansible_facts["user_dir"] }}/.config/karabiner/karabiner.json'
     state: link
     force: yes
   notify:

--- a/modules/playbooks/macos/roles/mas/tasks/main.yml
+++ b/modules/playbooks/macos/roles/mas/tasks/main.yml
@@ -4,6 +4,6 @@
 
 - name: Installing applications
   community.general.mas:
-    id: "{{ item }}"
+    id: '{{ item }}'
     state: present
-  loop: "{{ applications }}"
+  loop: '{{ applications }}'

--- a/modules/playbooks/macos/roles/vscode/tasks/main.yml
+++ b/modules/playbooks/macos/roles/vscode/tasks/main.yml
@@ -5,26 +5,26 @@
 
 - name: Creating required directories
   file:
-    path: "{{ ansible_env.HOME }}/Library/Application Support/Code/User"
+    path: '{{ ansible_facts["user_dir"] }}/Library/Application Support/Code/User'
     state: directory
 
 - name: Installing personal settings
   file:
-    src: "{{ sphynx_settings_directory }}/macos/vscode/{{ item }}"
-    dest: "{{ ansible_env.HOME }}/Library/Application Support/Code/User/{{ item }}"
+    src: '{{ sphynx_settings_directory }}/macos/vscode/{{ item }}'
+    dest: '{{ ansible_facts["user_dir"] }}/Library/Application Support/Code/User/{{ item }}'
     state: link
     force: yes
-  loop: "{{ configuration_files }}"
+  loop: '{{ configuration_files }}'
   notify:
     - Restart Visual Studio Code
 
 - name: Loading existing extensions
-  command: "code --list-extensions"
+  command: 'code --list-extensions'
   register: installed_extensions
   changed_when: false
 
 - name: Installing extensions
-  command: "code --install-extension {{ item }}"
-  loop: "{{ extensions }}"
+  command: 'code --install-extension {{ item }}'
+  loop: '{{ extensions }}'
   when:
     - item not in installed_extensions.stdout.split('\n')


### PR DESCRIPTION
Mostly `stdout_callback=yaml` and `ansible_env.HOME` due to (`INJECT_FACTS_AS_VARS`).